### PR TITLE
Downgrade to Windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   Windows:
-    runs-on: windows-2025
+    runs-on: windows-2022
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Downgrade the runner because Xenon is considered a virus because of this