### PR TITLE
Custom HW_INIT_SKIP

### DIFF
--- a/Xenon/Base/Config.cpp
+++ b/Xenon/Base/Config.cpp
@@ -33,7 +33,11 @@ static bool gpuRenderThreadEnabled = true;
 static bool isFullscreen = false;
 
 // SMC.
-static int smcPowerOnReason = 0x11; // Valid values are: 0x11 (SMC_PWR_REAS_PWRBTN) and 0x12 (SMC_PWR_REAS_EJECT). 
+static int smcPowerOnReason = 0x11; // Valid values are: 0x11 (SMC_PWR_REAS_PWRBTN) and 0x12 (SMC_PWR_REAS_EJECT).
+
+// PowerPC.
+static u64 SKIP_HW_INIT_1 = 0;
+static u64 SKIP_HW_INIT_2 = 0;
 
 static s32 screenWidth = 1280;
 static s32 screenHeight = 720;
@@ -50,6 +54,14 @@ bool gpuThreadEnabled() {
 
 int smcPowerOnType() {
     return smcPowerOnReason;
+}
+
+u64 HW_INIT_SKIP1() {
+    return SKIP_HW_INIT_1;
+}
+
+u64 HW_INIT_SKIP2() {
+    return SKIP_HW_INIT_2;
 }
 
 s32 windowWidth() {
@@ -92,6 +104,12 @@ void loadConfig(const std::filesystem::path& path) {
         smcPowerOnReason = toml::find_or<int>(smc, "SMCPowerOnType", false);
     }
 
+    if (data.contains("PowerPC")) {
+        const toml::value& powerpc = data.at("PowerPC");
+        SKIP_HW_INIT_1 = toml::find_or<u64>(powerpc, "HW_INIT_SKIP1", false);
+        SKIP_HW_INIT_2 = toml::find_or<u64>(powerpc, "HW_INIT_SKIP2", false);
+    }
+
     if (data.contains("GPU")) {
         const toml::value& gpu = data.at("GPU");
 
@@ -125,6 +143,10 @@ void saveConfig(const std::filesystem::path& path) {
 
     // SMC.
     data["SMC"]["SMCPowerOnType"] = smcPowerOnReason;
+
+    // PowerPC.
+    data["PowerPC"]["HW_INIT_SKIP1"] = SKIP_HW_INIT_1;
+    data["PowerPC"]["HW_INIT_SKIP2"] = SKIP_HW_INIT_2;
 
     // XGPU.
     data["GPU"]["screenWidth"] = screenWidth;

--- a/Xenon/Base/Config.h
+++ b/Xenon/Base/Config.h
@@ -28,10 +28,18 @@ bool gpuThreadEnabled();
 int smcPowerOnType();
 
 //
+// PowerPC Options.
+//
+
+// HW_INIT_SKIP
+u64 HW_INIT_SKIP1();
+u64 HW_INIT_SKIP2();
+
+//
 // XGPU Options.
 //
 
-// Screen W/H. 
+// Screen W/H.
 s32 windowWidth();
 s32 windowHeight();
 

--- a/Xenon/Core/XCPU/Interpreter/PPC_BC.cpp
+++ b/Xenon/Core/XCPU/Interpreter/PPC_BC.cpp
@@ -1,5 +1,7 @@
 // Copyright 2025 Xenon Emulator Project
 
+#include "Base/Config.h"
+
 #include "PPCInterpreter.h"
 
 void PPCInterpreter::PPCInterpreter_bc(PPU_STATE* hCore)
@@ -68,12 +70,19 @@ void PPCInterpreter::PPCInterpreter_bclr(PPU_STATE* hCore)
     // Jrunner XDK build offsets are 0x0000000003003f48 AND 0x0000000003003fdc
     // xell version are 0x0000000003003dc0 AND 0x0000000003003e54
 
-    // HW_INIT Skip on XDK 17.489.0
-    if (hCore->ppuThread[hCore->currentThread].CIA == 0x0000000003003f48)
-       condOk = false;
+	if (Config::HW_INIT_SKIP1() != 0) {
+		if (hCore->ppuThread[hCore->currentThread].CIA == Config::HW_INIT_SKIP1())
+		condOk = false;
 
-    if (hCore->ppuThread[hCore->currentThread].CIA == 0x0000000003003fdc)
-       condOk = true;
+		if (hCore->ppuThread[hCore->currentThread].CIA == Config::HW_INIT_SKIP2())
+		condOk = true;
+	} else {
+		if (hCore->ppuThread[hCore->currentThread].CIA == 0x0000000003003f48)
+		condOk = false;
+
+		if (hCore->ppuThread[hCore->currentThread].CIA == 0x0000000003003fdc)
+		condOk = true;
+	}
 
     if (ctrOk && condOk)
     {


### PR DESCRIPTION
This allows to use custom HW_INIT_SKIP.
Useful for Xell Reloaded.